### PR TITLE
Add shellprocess for i386 multiarch

### DIFF
--- a/ubuntudde/modules/shellprocess_add386arch.conf
+++ b/ubuntudde/modules/shellprocess_add386arch.conf
@@ -1,0 +1,5 @@
+---
+dontChroot: false
+timeout: 30
+script:
+    - command: "/usr/bin/dpkg --add-architecture i386"

--- a/ubuntudde/settings.conf
+++ b/ubuntudde/settings.conf
@@ -17,6 +17,9 @@ instances:
 - id: bug-LP#1829805
   module: shellprocess
   config: shellprocess_bug-LP#1829805.conf
+- id: add386arch
+  module: shellprocess
+  config: shellprocess_add386arch.conf
 
 sequence:
 - show:
@@ -49,6 +52,7 @@ sequence:
   - bootloader
   - contextualprocess@after_bootloader
   - automirror
+  - shellprocess@add386arch
   - packages
   - shellprocess@logs
   - umount


### PR DESCRIPTION
This enables the i386 architecture so that things like Steam can be installed. And addresses this issue: https://github.com/UbuntuDDE/bugs/issues/32